### PR TITLE
Deprecate system secret security scan readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ All ClearBlade Adapters require a certain set of System specific variables to st
 | Name | CLI Flag | Environment Variable | Default |
 | --- | --- | --- | --- |
 | System Key | `systemKey` | `CB_SYSTEM_KEY` | N/A |
-| System Secret | `systemSecret` | `CB_SYSTEM_SECRET` | N/A |
 | Platform/Edge URL | `platformURL` | N/A | `http://localhost:9000` |
 | Platform/Edge Messaging URL | `messagingURL` | N/A | `localhost:1883` |
 | Device Name (**depreciated**) | `deviceName` | N/A | `adapterName` provided when calling `adapter_library.ParseArguments` |
@@ -74,7 +73,7 @@ All ClearBlade Adapters require a certain set of System specific variables to st
 | Log Level | `logLevel` | N/A | `info` |
 | Adapter Config Collection Name | `adapterConfigCollection` | N/A | `adapter_config` |
 
-A System Key and System Secret will always be required to start the adapter, and it's recommended to always use a Device Service Account & Token for Adapters. 
+A System Key will always be required to start the adapter, and it's recommended to always use a Device Service Account & Token for Adapters. 
 
 Device Name and Password for Adapters are **depreciated** and only provided for backwards compatibility and should not be used for any new adapters.
 

--- a/README.md
+++ b/README.md
@@ -66,17 +66,12 @@ All ClearBlade Adapters require a certain set of System specific variables to st
 | System Key | `systemKey` | `CB_SYSTEM_KEY` | N/A |
 | Platform/Edge URL | `platformURL` | N/A | `http://localhost:9000` |
 | Platform/Edge Messaging URL | `messagingURL` | N/A | `localhost:1883` |
-| Device Name (**depreciated**) | `deviceName` | N/A | `adapterName` provided when calling `adapter_library.ParseArguments` |
-| Device Password/Active Key (**depreciated)** | `password` | N/A | N/A |
 | Device Service Account | N/A | `CB_SERVICE_ACCOUNT` | N/A |
 | Device Service Account Token | N/A | `CB_SERVICE_ACCOUNT_TOKEN` | N/A |
 | Log Level | `logLevel` | N/A | `info` |
 | Adapter Config Collection Name | `adapterConfigCollection` | N/A | `adapter_config` |
 
 A System Key will always be required to start the adapter, and it's recommended to always use a Device Service Account & Token for Adapters. 
-
-Device Name and Password for Adapters are **depreciated** and only provided for backwards compatibility and should not be used for any new adapters.
-
 
 ## Adapter Configuration & Settings
 This library does require the use of an Adapter Configuration Collection. This allows you to easily provide configuration options to your adapter at runtime via this Collection, rather than command line arguments, environment variables, or hardcoded values in your adapter. 
@@ -97,8 +92,5 @@ This adapter introduces some basic logging level that your adapter can also leve
 The supported log levels are `DEBUG`, `INFO`, `ERROR`, and `FATAL`.
 
 ## Fatal Errors
-There are a few cases where this library will encounter a fatal error and cause your adapter to quit. A log with more information will be provided, but as a heads up these are the current cases that will cause the adapter to exit from within the library:
-
-1. If your adapter subscribes to a topic and the device account used by the adapter does not have subscribe permissions on this topic
-2. If you are using a **depreciated** device name and password for authentication and MQTT disconnects for any reason. This is to force the adapter to reauth with the Platform/Edge incase the current auth token has reached it's TTL or the session has been manually removed.
+There are a few cases where this library will encounter a fatal error and cause your adapter to quit. A log with more information will be provided (e.g. If your adapter subscribes to a topic and the device account used by the adapter does not have subscribe permissions on this topic)
 

--- a/clearblade.go
+++ b/clearblade.go
@@ -56,7 +56,7 @@ func PublishGetToken(topic string, message []byte) (mqtt.Token, error) {
 
 func authWithDevice() error {
 	log.Println("[INFO] authWithDevice - Authenticating with ClearBlade Edge or Platform as a Device")
-	log.Println("[ERROR] authWithDevice - This functionality is depreciated! Please use a Device Service Account instead")
+	log.Println("[ERROR] authWithDevice - This functionality is deprecated! Please use a Device Service Account instead")
 	//Passing "" in place of system secret (deprecated since CB 9.38.0)
 	deviceClient = cb.NewDeviceClientWithAddrs(Args.PlatformURL, Args.MessagingURL, Args.SystemKey, "", Args.DeviceName, Args.ActiveKey)
 	_, err := deviceClient.Authenticate()

--- a/clearblade.go
+++ b/clearblade.go
@@ -57,14 +57,16 @@ func PublishGetToken(topic string, message []byte) (mqtt.Token, error) {
 func authWithDevice() error {
 	log.Println("[INFO] authWithDevice - Authenticating with ClearBlade Edge or Platform as a Device")
 	log.Println("[ERROR] authWithDevice - This functionality is depreciated! Please use a Device Service Account instead")
-	deviceClient = cb.NewDeviceClientWithAddrs(Args.PlatformURL, Args.MessagingURL, Args.SystemKey, Args.SystemSecret, Args.DeviceName, Args.ActiveKey)
+	//Passing "" in place of system secret (deprecated since CB 9.38.0)
+	deviceClient = cb.NewDeviceClientWithAddrs(Args.PlatformURL, Args.MessagingURL, Args.SystemKey, "", Args.DeviceName, Args.ActiveKey)
 	_, err := deviceClient.Authenticate()
 	return err
 }
 
 func authWithServiceAccount() error {
 	log.Println("[INFO] authWithServiceAccount - Authenticating with ClearBlade Edge or Platform using a Service Account")
-	deviceClient = cb.NewDeviceClientWithServiceAccountAndAddrs(Args.PlatformURL, Args.MessagingURL, Args.SystemKey, Args.SystemSecret, Args.ServiceAccount, Args.ServiceAccountToken)
+	//Passing "" in place of system secret (deprecated since CB 9.38.0)
+	deviceClient = cb.NewDeviceClientWithServiceAccountAndAddrs(Args.PlatformURL, Args.MessagingURL, Args.SystemKey, "", Args.ServiceAccount, Args.ServiceAccountToken)
 	return nil
 }
 
@@ -73,7 +75,7 @@ func FetchAdapterConfig() (*AdapterConfig, error) {
 	config := &AdapterConfig{
 		TopicRoot: Args.DeviceName,
 	}
-
+	fmt.Printf("ANS EdgeName: %s\n", Args.EdgeName)
 	//Retrieve the adapter configuration row
 	query := cb.NewQuery()
 	if Args.EdgeName != "" {
@@ -99,7 +101,7 @@ func FetchAdapterConfig() (*AdapterConfig, error) {
 	if len(data) > 0 {
 		log.Println("[INFO] fetchAdapterConfig - Adapter config retrieved")
 		configData := data[0].(map[string]interface{})
-
+		fmt.Printf("ANS configData['topic_root']: %s\n", configData["topic_root"])
 		//MQTT topic root
 		if configData["topic_root"] != nil && configData["topic_root"] != "" {
 			config.TopicRoot = configData["topic_root"].(string)

--- a/clearblade.go
+++ b/clearblade.go
@@ -75,7 +75,7 @@ func FetchAdapterConfig() (*AdapterConfig, error) {
 	config := &AdapterConfig{
 		TopicRoot: Args.DeviceName,
 	}
-	fmt.Printf("ANS EdgeName: %s\n", Args.EdgeName)
+
 	//Retrieve the adapter configuration row
 	query := cb.NewQuery()
 	if Args.EdgeName != "" {
@@ -101,7 +101,7 @@ func FetchAdapterConfig() (*AdapterConfig, error) {
 	if len(data) > 0 {
 		log.Println("[INFO] fetchAdapterConfig - Adapter config retrieved")
 		configData := data[0].(map[string]interface{})
-		fmt.Printf("ANS configData['topic_root']: %s\n", configData["topic_root"])
+
 		//MQTT topic root
 		if configData["topic_root"] != nil && configData["topic_root"] != "" {
 			config.TopicRoot = configData["topic_root"].(string)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/clearblade/adapter-go-library
 
-go 1.20
+go 1.24.0
 
 require (
 	github.com/clearblade/Go-SDK v0.0.0-20220811134357-78291979ad51
@@ -12,5 +12,5 @@ require (
 require (
 	github.com/clearblade/go-utils v1.1.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	golang.org/x/net v0.27.0 // indirect
+	golang.org/x/net v0.47.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,15 +8,12 @@ github.com/clearblade/paho.mqtt.golang v1.1.1 h1:S+F3zt3EuskNZvrP4NTgtH1gbY/gvz8
 github.com/clearblade/paho.mqtt.golang v1.1.1/go.mod h1:rpDRqEw2Q7epfQYfcHwkHDHSzNzPB+BYO8zn7cGHsWo=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20211101193420-4a448f8816b3 h1:VrJZAjbekhoRn7n5FBujY31gboH+iB3pdLxn3gE9FjU=
-golang.org/x/net v0.0.0-20211101193420-4a448f8816b3/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.27.0 h1:5K3Njcw06/l2y9vpGCSdcxWOYHOUk3dVNGDXN+FvAys=
-golang.org/x/net v0.27.0/go.mod h1:dDi0PyhWNoiUOrAS8uXv/vnScO4wnHQO4mj9fn/RytE=
+golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=
+golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/initialize.go
+++ b/initialize.go
@@ -24,7 +24,6 @@ var (
 type adapterArgs struct {
 	LogLevel                string
 	SystemKey               string
-	SystemSecret            string
 	DeviceName              string
 	EdgeName                string
 	ActiveKey               string
@@ -42,7 +41,6 @@ func ParseArguments(adapterName string) error {
 	Args = adapterArgs{
 		LogLevel:                defaultLogLevel,
 		SystemKey:               "",
-		SystemSecret:            "",
 		DeviceName:              adapterName,
 		EdgeName:                "",
 		ActiveKey:               "",
@@ -55,7 +53,6 @@ func ParseArguments(adapterName string) error {
 	}
 
 	flag.StringVar(&Args.SystemKey, "systemKey", "", "system key (required)")
-	flag.StringVar(&Args.SystemSecret, "systemSecret", "", "system secret (required)")
 	flag.StringVar(&Args.DeviceName, "deviceName", adapterName, "name of device (optional)")
 	flag.StringVar(&Args.ActiveKey, "password", "", "password (or active key) for device authentication (required)")
 	flag.StringVar(&Args.PlatformURL, "platformURL", defaultPlatformURL, "platform url (optional)")
@@ -72,11 +69,6 @@ func ParseArguments(adapterName string) error {
 	if ok && Args.SystemKey == "" {
 		Args.SystemKey = sysKey
 		log.Println("[DEBUG] Using ClearBlade System Key From Environment Variable")
-	}
-	sysSec, ok := os.LookupEnv("CB_SYSTEM_SECRET")
-	if ok && Args.SystemSecret == "" {
-		Args.SystemSecret = sysSec
-		log.Println("[DEBUG] Using ClearBlade System Secret From Environment Variable")
 	}
 	servAcc, ok := os.LookupEnv("CB_SERVICE_ACCOUNT")
 	if ok {
@@ -95,9 +87,6 @@ func ParseArguments(adapterName string) error {
 	// verify all required fields are present
 	if Args.SystemKey == "" {
 		return fmt.Errorf("System Key is required, can be supplied with --systemKey flag or CB_SYSTEM_KEY environment variable")
-	}
-	if Args.SystemSecret == "" {
-		return fmt.Errorf("System Secret is required, can be supplied with --systemSecret flag or CB_SYSTEM_SECRET environment variable")
 	}
 	if Args.ActiveKey == "" && Args.ServiceAccount == "" {
 		return fmt.Errorf("Device Password is required when not using a Service Account, can be supplied with --password flag")


### PR DESCRIPTION
- System secret removed wherever possible (passing ““ when calling Go-SDK and added comments to explain).
- README updated accordingly.
- Dependencies updated.
- Ran trivy scan which revealed 0 vulnerabilities.